### PR TITLE
Add GitHub-Style Alert Markdown Support

### DIFF
--- a/app/src/main/assets/template.html
+++ b/app/src/main/assets/template.html
@@ -64,6 +64,86 @@
         tr:nth-child(even) { background-color: {{PRE_BACKGROUND}}; }
         video::-webkit-media-controls-fullscreen-button { display: none !important; }
         video, audio { width: 100%; }
+
+      /* Alert Styles */
+        .markdown-alert {
+            padding: 0;
+            margin: 16px 0;
+            border-left: 4px solid;
+        }
+
+        .markdown-alert p {
+            margin-left: 16px;
+            margin-right: 16px;
+            color: inherit; /* Changed from #444 to inherit body text color */
+        }
+
+        .markdown-alert p:first-of-type {
+            margin-top: 4px;
+            padding-top: 0;
+        }
+
+        .markdown-alert p:last-of-type {
+            margin-bottom: 0;
+            padding-bottom: 16px;
+        }
+
+        .markdown-alert-title {
+            font-weight: 500;
+            display: flex;
+            align-items: center;
+            padding: 8px 16px;
+        }
+
+        .markdown-alert-title svg {
+            margin-right: 8px;
+        }
+
+        .markdown-alert-title svg path {
+            fill: currentColor;
+        }
+
+        /* Alert title colors */
+        .markdown-alert.note .markdown-alert-title {
+            color: #4493f8;
+        }
+
+        .markdown-alert.tip .markdown-alert-title {
+            color: #3fb950;
+        }
+
+        .markdown-alert.important .markdown-alert-title {
+            color: #ab7df8;
+        }
+
+        .markdown-alert.warning .markdown-alert-title {
+            color: #d29922;
+        }
+
+        .markdown-alert.caution .markdown-alert-title {
+            color: #f85149;
+        }
+
+        /* Border colors */
+        .markdown-alert.note {
+            border-color: #4493f8;
+        }
+
+        .markdown-alert.tip {
+            border-color: #3fb950;
+        }
+
+        .markdown-alert.important {
+            border-color: #ab7df8;
+        }
+
+        .markdown-alert.warning {
+            border-color: #d29922;
+        }
+
+        .markdown-alert.caution {
+            border-color: #f85149;
+        }
     </style>
 
     <!-- Async CSS loading -->
@@ -84,6 +164,7 @@
             handlers.processAudio();
             handlers.processVideos();
             handlers.processCheckboxLists();
+            handlers.processAlerts();
         },
 
         processImages: () => {
@@ -143,6 +224,70 @@
                 if (li.querySelector('input[type="checkbox"]')) {
                     li.style.listStyleType = 'none';
                 }
+            });
+        },
+
+        processAlerts: () => {
+            // Process GitHub-style markdown alerts
+            document.querySelectorAll('blockquote').forEach(blockquote => {
+                const firstParagraph = blockquote.querySelector('p:first-child');
+                if (!firstParagraph) return;
+
+                const alertMatch = firstParagraph.textContent.match(/^\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)\]\s*(.*)/i);
+                if (!alertMatch) return;
+
+                const iconPaths = {
+                    note: 'M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z',
+                    tip: 'M8 1.5c-2.363 0-4 1.69-4 3.75 0 .984.424 1.625.984 2.304l.214.253c.223.264.47.556.673.848.284.411.537.896.621 1.49a.75.75 0 0 1-1.484.211c-.04-.282-.163-.547-.37-.847a8.456 8.456 0 0 0-.542-.68c-.084-.1-.173-.205-.268-.32C3.201 7.75 2.5 6.766 2.5 5.25 2.5 2.31 4.863 0 8 0s5.5 2.31 5.5 5.25c0 1.516-.701 2.5-1.328 3.259-.095.115-.184.22-.268.319-.207.245-.383.453-.541.681-.208.3-.33.565-.37.847a.751.751 0 0 1-1.485-.212c.084-.593.337-1.078.621-1.489.203-.292.45-.584.673-.848.075-.088.147-.173.213-.253.561-.679.985-1.32.985-2.304 0-2.06-1.637-3.75-4-3.75ZM5.75 12h4.5a.75.75 0 0 1 0 1.5h-4.5a.75.75 0 0 1 0-1.5ZM6 15.25a.75.75 0 0 1 .75-.75h2.5a.75.75 0 0 1 0 1.5h-2.5a.75.75 0 0 1-.75-.75Z',
+                    important: 'M0 1.75C0 .784.784 0 1.75 0h12.5C15.216 0 16 .784 16 1.75v9.5A1.75 1.75 0 0 1 14.25 13H8.06l-2.573 2.573A1.458 1.458 0 0 1 3 14.543V13H1.75A1.75 1.75 0 0 1 0 11.25Zm1.75-.25a.25.25 0 0 0-.25.25v9.5c0 .138.112.25.25.25h2a.75.75 0 0 1 .75.75v2.19l2.72-2.72a.749.749 0 0 1 .53-.22h6.5a.25.25 0 0 0 .25-.25v-9.5a.25.25 0 0 0-.25-.25Zm7 2.25v2.5a.75.75 0 0 1-1.5 0v-2.5a.75.75 0 0 1 1.5 0ZM9 9a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z',
+                    warning: 'M6.457 1.047c.659-1.234 2.427-1.234 3.086 0l6.082 11.378A1.75 1.75 0 0 1 14.082 15H1.918a1.75 1.75 0 0 1-1.543-2.575Zm1.763.707a.25.25 0 0 0-.44 0L1.698 13.132a.25.25 0 0 0 .22.368h12.164a.25.25 0 0 0 .22-.368Zm.53 3.996v2.5a.75.75 0 0 1-1.5 0v-2.5a.75.75 0 0 1 1.5 0ZM9 11a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z',
+                    caution: 'M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z'
+                };
+
+                const alertType = alertMatch[1].toLowerCase();
+                const alertTitle = alertType.charAt(0).toUpperCase() + alertType.slice(1);
+                const additionalTitleText = alertMatch[2] ? alertMatch[2] : '';
+
+                // Create alert container
+                const alertDiv = document.createElement('div');
+                alertDiv.className = `markdown-alert ${alertType}`;
+
+                // Create title element with SVG icon
+                const titleDiv = document.createElement('div');
+                titleDiv.className = 'markdown-alert-title';
+
+                if (iconPaths[alertType]) {
+                    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+                    svg.setAttribute('viewBox', '0 0 16 16');
+                    svg.setAttribute('width', '16');
+                    svg.setAttribute('height', '16');
+                    const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+                    path.setAttribute('d', iconPaths[alertType]);
+                    svg.appendChild(path);
+                    titleDiv.appendChild(svg);
+                }
+
+                const titleText = document.createTextNode(alertTitle);
+                titleDiv.appendChild(titleText);
+                alertDiv.appendChild(titleDiv);
+
+                // Create content paragraph if there's additional text
+                if (additionalTitleText) {
+                    const contentParagraph = document.createElement('p');
+                    contentParagraph.textContent = additionalTitleText;
+                    alertDiv.appendChild(contentParagraph);
+                }
+
+                // Remove the first paragraph
+                firstParagraph.remove();
+
+                // Move remaining content to the alert
+                while (blockquote.firstChild) {
+                    alertDiv.appendChild(blockquote.firstChild);
+                }
+
+                // Replace blockquote with our custom alert
+                blockquote.parentNode.replaceChild(alertDiv, blockquote);
             });
         }
     };

--- a/app/src/main/java/com/yangdai/opennote/presentation/component/note/EditorRow.kt
+++ b/app/src/main/java/com/yangdai/opennote/presentation/component/note/EditorRow.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.FormatIndentDecrease
 import androidx.compose.material.icons.automirrored.outlined.FormatIndentIncrease
+import androidx.compose.material.icons.automirrored.outlined.Label
 import androidx.compose.material.icons.automirrored.outlined.List
 import androidx.compose.material.icons.automirrored.outlined.TextSnippet
 import androidx.compose.material.icons.outlined.AddChart
@@ -21,6 +22,7 @@ import androidx.compose.material.icons.outlined.CheckBox
 import androidx.compose.material.icons.outlined.Code
 import androidx.compose.material.icons.outlined.DataArray
 import androidx.compose.material.icons.outlined.DataObject
+import androidx.compose.material.icons.outlined.Feedback
 import androidx.compose.material.icons.outlined.FormatBold
 import androidx.compose.material.icons.outlined.FormatItalic
 import androidx.compose.material.icons.outlined.FormatPaint
@@ -28,12 +30,16 @@ import androidx.compose.material.icons.outlined.FormatQuote
 import androidx.compose.material.icons.outlined.FormatUnderlined
 import androidx.compose.material.icons.outlined.HorizontalRule
 import androidx.compose.material.icons.outlined.Image
+import androidx.compose.material.icons.outlined.Info
+import androidx.compose.material.icons.outlined.Lightbulb
 import androidx.compose.material.icons.outlined.Link
 import androidx.compose.material.icons.outlined.Mic
+import androidx.compose.material.icons.outlined.ReportGmailerrorred
 import androidx.compose.material.icons.outlined.StrikethroughS
 import androidx.compose.material.icons.outlined.TableChart
 import androidx.compose.material.icons.outlined.Title
 import androidx.compose.material.icons.outlined.VideoFile
+import androidx.compose.material.icons.outlined.Warning
 import androidx.compose.material3.BottomAppBarDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -77,7 +83,8 @@ fun RichTextEditorRowPreview() {
         onCodeClick = {},
         onBracketsClick = {},
         onBracesClick = {},
-        onTemplateClick = {}
+        onTemplateClick = {},
+        onAlertClick = {},
     )
 }
 
@@ -154,10 +161,13 @@ fun RichTextEditorRow(
     onCodeClick: () -> Unit,
     onBracketsClick: () -> Unit,
     onBracesClick: () -> Unit,
-    onTemplateClick: () -> Unit
+    onTemplateClick: () -> Unit,
+    onAlertClick: (Constants.AlertType) -> Unit,
 ) {
 
     var isExpanded by rememberSaveable { mutableStateOf(false) }
+    var isAlertExpanded by rememberSaveable { mutableStateOf(false) }
+
 
     Column {
 
@@ -303,6 +313,55 @@ fun RichTextEditorRow(
                 shortCutDescription = "Ctrl + Shift + P",
                 onClick = onTemplateClick
             )
+
+
+            IconButtonWithTooltip(
+                imageVector = Icons.AutoMirrored.Outlined.Label,
+                contentDescription = stringResource(id = R.string.alert),
+            ) {
+                isAlertExpanded = !isAlertExpanded
+            }
+
+            AnimatedVisibility(visible = isAlertExpanded) {
+                Row(
+                    modifier = Modifier.fillMaxHeight(),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.Start
+                ) {
+                    IconButtonWithTooltip(
+                        imageVector = Icons.Outlined.Info,
+                        contentDescription = stringResource(R.string.note_alert),
+                    ) {
+                        onAlertClick(Constants.AlertType.INFO)
+                    }
+
+                    IconButtonWithTooltip(
+                        imageVector = Icons.Outlined.Lightbulb,
+                        contentDescription = stringResource(R.string.tip_alert),
+                    ) {
+                        onAlertClick(Constants.AlertType.TIP)
+                    }
+                    IconButtonWithTooltip(
+                        imageVector = Icons.Outlined.Feedback,
+                        contentDescription = stringResource(R.string.important_alert),
+                    ) {
+                        onAlertClick(Constants.AlertType.IMPORTANT)
+                    }
+                    IconButtonWithTooltip(
+                        imageVector = Icons.Outlined.Warning,
+                        contentDescription = stringResource(R.string.warning_alert),
+                    ) {
+                        onAlertClick(Constants.AlertType.WARNING)
+                    }
+
+                    IconButtonWithTooltip(
+                        imageVector = Icons.Outlined.ReportGmailerrorred,
+                        contentDescription = stringResource(R.string.caution_alert),
+                    ) {
+                        onAlertClick(Constants.AlertType.CAUTION)
+                    }
+                }
+            }
         }
     }
 }
@@ -323,6 +382,8 @@ fun MarkdownEditorRow(
 ) {
 
     var isExpanded by rememberSaveable { mutableStateOf(false) }
+    var isAlertExpanded by rememberSaveable { mutableStateOf(false) }
+
 
     Row(
         Modifier
@@ -506,6 +567,57 @@ fun MarkdownEditorRow(
             shortCutDescription = "Ctrl + Shift + Q"
         ) {
             onEdit(Constants.Editor.QUOTE)
+        }
+
+        IconButtonWithTooltip(
+            imageVector = Icons.AutoMirrored.Outlined.Label,
+            contentDescription = stringResource(id = R.string.alert),
+        ) {
+            isAlertExpanded = !isAlertExpanded
+        }
+
+        AnimatedVisibility(visible = isAlertExpanded) {
+            Row(
+                modifier = Modifier.fillMaxHeight(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.Start
+            ) {
+                IconButtonWithTooltip(
+                    imageVector = Icons.Outlined.Info,
+                    contentDescription = stringResource(R.string.note_alert),
+                ) {
+                    onEdit(Constants.Editor.NOTE)
+                }
+
+                IconButtonWithTooltip(
+                    imageVector = Icons.Outlined.Lightbulb,
+                    contentDescription = stringResource(R.string.tip_alert),
+                ) {
+                    onEdit(Constants.Editor.TIP)
+                }
+
+                IconButtonWithTooltip(
+                    imageVector = Icons.Outlined.Feedback,
+                    contentDescription = stringResource(R.string.important_alert),
+                ) {
+                    onEdit(Constants.Editor.IMPORTANT)
+
+                }
+                IconButtonWithTooltip(
+                    imageVector = Icons.Outlined.Warning,
+                    contentDescription = stringResource(R.string.warning_alert),
+                ) {
+                    onEdit(Constants.Editor.WARNING)
+                }
+
+                IconButtonWithTooltip(
+                    imageVector = Icons.Outlined.ReportGmailerrorred,
+                    contentDescription = stringResource(R.string.caution_alert),
+                ) {
+                    onEdit(Constants.Editor.CAUTION)
+
+                }
+            }
         }
 
         IconButtonWithTooltip(

--- a/app/src/main/java/com/yangdai/opennote/presentation/component/note/LiteModeMutators.kt
+++ b/app/src/main/java/com/yangdai/opennote/presentation/component/note/LiteModeMutators.kt
@@ -165,3 +165,20 @@ fun TextFieldValue.header(level: Int): TextFieldValue {
     val headerString = "#".repeat(level)
     return add("$headerString ")
 }
+
+fun TextFieldValue.alert(type: String): TextFieldValue {
+    val alertType = "> [!$type]"
+    val alertContent = text.substring(selection.min, selection.max)
+    val newText = text.replaceRange(
+        selection.min,
+        selection.max,
+        "$alertType $alertContent"
+    )
+    return TextFieldValue(
+        text = newText,
+        selection = TextRange(
+            selection.min + alertType.length,
+            selection.min + alertType.length + alertContent.length
+        )
+    )
+}

--- a/app/src/main/java/com/yangdai/opennote/presentation/component/note/LiteTextField.kt
+++ b/app/src/main/java/com/yangdai/opennote/presentation/component/note/LiteTextField.kt
@@ -419,7 +419,10 @@ fun LiteTextField(
                         applyChange(textFieldValue.brackets())
                     }, onBracesClick = {
                         applyChange(textFieldValue.braces())
-                    }, onTemplateClick = onTemplateClick
+                    }, onTemplateClick = onTemplateClick,
+                    onAlertClick = {
+                        applyChange(textFieldValue.alert(it.name))
+                    }
                 )
             }
         }

--- a/app/src/main/java/com/yangdai/opennote/presentation/component/note/StandardModeMutators.kt
+++ b/app/src/main/java/com/yangdai/opennote/presentation/component/note/StandardModeMutators.kt
@@ -206,6 +206,29 @@ fun TextFieldBuffer.quote() {
     )
 }
 
+fun TextFieldBuffer.alert(type: String) {
+    val text = toString()
+    val lineStart = text.take(selection.min)
+        .lastIndexOf('\n')
+        .takeIf { it != -1 }
+        ?.let { it + 1 }
+        ?: 0
+
+    val initialSelection = selection
+    val alertType = "> [!$type]"
+    replace(lineStart, lineStart, alertType)
+    replace(
+        lineStart + alertType.length,
+        lineStart + alertType.length,
+        "\n> "
+    )
+    selection = TextRange(
+        initialSelection.min + type.length + 2,
+        initialSelection.max + type.length + 2
+    )
+}
+
+
 fun TextFieldBuffer.tab() {
     val text = toString()
     val lineStart = text.take(selection.min)

--- a/app/src/main/java/com/yangdai/opennote/presentation/util/Constants.kt
+++ b/app/src/main/java/com/yangdai/opennote/presentation/util/Constants.kt
@@ -78,12 +78,25 @@ object Constants {
         const val TASK = "task"
         const val LIST = "list"
         const val QUOTE = "quote"
+        const val NOTE = "note"
+        const val TIP = "tip"
+        const val IMPORTANT = "important"
+        const val WARNING = "warning"
+        const val CAUTION = "caution"
         const val TAB = "tab"
         const val UN_TAB = "unTab"
         const val RULE = "rule"
         const val DIAGRAM = "diagram"
 
         const val TEXT = "text"
+    }
+
+    enum class AlertType(val value: String) {
+        INFO("info"),
+        TIP("tip"),
+        IMPORTANT("important"),
+        WARNING("warning"),
+        CAUTION("caution"),
     }
 }
 

--- a/app/src/main/java/com/yangdai/opennote/presentation/viewmodel/FileViewModel.kt
+++ b/app/src/main/java/com/yangdai/opennote/presentation/viewmodel/FileViewModel.kt
@@ -20,13 +20,14 @@ import com.yangdai.opennote.presentation.component.note.addMermaid
 import com.yangdai.opennote.presentation.component.note.addRule
 import com.yangdai.opennote.presentation.component.note.addTable
 import com.yangdai.opennote.presentation.component.note.addTask
+import com.yangdai.opennote.presentation.component.note.alert
 import com.yangdai.opennote.presentation.component.note.bold
+import com.yangdai.opennote.presentation.component.note.highlight
 import com.yangdai.opennote.presentation.component.note.inlineBraces
 import com.yangdai.opennote.presentation.component.note.inlineBrackets
 import com.yangdai.opennote.presentation.component.note.inlineCode
 import com.yangdai.opennote.presentation.component.note.inlineMath
 import com.yangdai.opennote.presentation.component.note.italic
-import com.yangdai.opennote.presentation.component.note.highlight
 import com.yangdai.opennote.presentation.component.note.quote
 import com.yangdai.opennote.presentation.component.note.strikeThrough
 import com.yangdai.opennote.presentation.component.note.tab
@@ -220,6 +221,11 @@ class FileViewModel @Inject constructor(
                     Constants.Editor.INLINE_BRACES -> contentState.edit { inlineBraces() }
                     Constants.Editor.INLINE_MATH -> contentState.edit { inlineMath() }
                     Constants.Editor.QUOTE -> contentState.edit { quote() }
+                    Constants.Editor.NOTE -> contentState.edit { alert(event.key.uppercase()) }
+                    Constants.Editor.TIP -> contentState.edit { alert(event.key.uppercase()) }
+                    Constants.Editor.IMPORTANT -> contentState.edit { alert(event.key.uppercase()) }
+                    Constants.Editor.WARNING -> contentState.edit { alert(event.key.uppercase()) }
+                    Constants.Editor.CAUTION -> contentState.edit { alert(event.key.uppercase()) }
                     Constants.Editor.TAB -> contentState.edit { tab() }
                     Constants.Editor.UN_TAB -> contentState.edit { unTab() }
                     Constants.Editor.RULE -> contentState.edit { addRule() }

--- a/app/src/main/java/com/yangdai/opennote/presentation/viewmodel/SharedViewModel.kt
+++ b/app/src/main/java/com/yangdai/opennote/presentation/viewmodel/SharedViewModel.kt
@@ -29,13 +29,14 @@ import com.yangdai.opennote.presentation.component.note.addMermaid
 import com.yangdai.opennote.presentation.component.note.addRule
 import com.yangdai.opennote.presentation.component.note.addTable
 import com.yangdai.opennote.presentation.component.note.addTask
+import com.yangdai.opennote.presentation.component.note.alert
 import com.yangdai.opennote.presentation.component.note.bold
+import com.yangdai.opennote.presentation.component.note.highlight
 import com.yangdai.opennote.presentation.component.note.inlineBraces
 import com.yangdai.opennote.presentation.component.note.inlineBrackets
 import com.yangdai.opennote.presentation.component.note.inlineCode
 import com.yangdai.opennote.presentation.component.note.inlineMath
 import com.yangdai.opennote.presentation.component.note.italic
-import com.yangdai.opennote.presentation.component.note.highlight
 import com.yangdai.opennote.presentation.component.note.quote
 import com.yangdai.opennote.presentation.component.note.strikeThrough
 import com.yangdai.opennote.presentation.component.note.tab
@@ -553,6 +554,11 @@ class SharedViewModel @Inject constructor(
                     Constants.Editor.INLINE_BRACES -> contentState.edit { inlineBraces() }
                     Constants.Editor.INLINE_MATH -> contentState.edit { inlineMath() }
                     Constants.Editor.QUOTE -> contentState.edit { quote() }
+                    Constants.Editor.NOTE -> contentState.edit { alert(event.key.uppercase()) }
+                    Constants.Editor.TIP -> contentState.edit { alert(event.key.uppercase()) }
+                    Constants.Editor.IMPORTANT -> contentState.edit { alert(event.key.uppercase()) }
+                    Constants.Editor.WARNING -> contentState.edit { alert(event.key.uppercase()) }
+                    Constants.Editor.CAUTION -> contentState.edit { alert(event.key.uppercase()) }
                     Constants.Editor.TAB -> contentState.edit { tab() }
                     Constants.Editor.UN_TAB -> contentState.edit { unTab() }
                     Constants.Editor.RULE -> contentState.edit { addRule() }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -94,11 +94,11 @@
     <string name="code">Code</string>
     <string name="quote">Zitat</string>
     <string name="alert">Alert</string>
-    <string name="caution_alert">Vorsichtsalarm</string>
-    <string name="warning_alert">Warnung Alert</string>
-    <string name="important_alert">Wichtig Alert</string>
-    <string name="tip_alert">Tipp Alert</string>
-    <string name="note_alert">Hinweis Warnung</string>
+    <string name="caution_alert">Vorsicht Alarm</string>
+    <string name="warning_alert">Warnungs Alarm</string>
+    <string name="important_alert">Wichtiger Alarm</string>
+    <string name="tip_alert">Tipp Alarm</string>
+    <string name="note_alert">Notiz Alarm</string>
     <string name="math">Mathe</string>
     <string name="horizontal_rule">Horizontale Linie</string>
     <string name="task_list">Aufgabenliste</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -93,6 +93,12 @@
     <string name="preview">Vorschau</string>
     <string name="code">Code</string>
     <string name="quote">Zitat</string>
+    <string name="alert">Alert</string>
+    <string name="caution_alert">Vorsichtsalarm</string>
+    <string name="warning_alert">Warnung Alert</string>
+    <string name="important_alert">Wichtig Alert</string>
+    <string name="tip_alert">Tipp Alert</string>
+    <string name="note_alert">Hinweis Warnung</string>
     <string name="math">Mathe</string>
     <string name="horizontal_rule">Horizontale Linie</string>
     <string name="task_list">Aufgabenliste</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -94,9 +94,9 @@
     <string name="quote">Alıntı</string>
     <string name="alert">Uyanık</string>
     <string name="caution_alert">Dikkat Uyarısı</string>
-    <string name="warning_alert">Uyarı Uyarısı</string>
+    <string name="warning_alert">Uyarı Alarmı</string>
     <string name="important_alert">Önemli Uyarı</string>
-    <string name="tip_alert">Bahşiş Uyarısı</string>
+    <string name="tip_alert">İpucu Uyarısı</string>
     <string name="note_alert">Not Uyarısı</string>
     <string name="math">Matematik</string>
     <string name="horizontal_rule">Yatay Çizgi</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -92,6 +92,12 @@
     <string name="preview">Önizleme</string>
     <string name="code">Kod</string>
     <string name="quote">Alıntı</string>
+    <string name="alert">Uyanık</string>
+    <string name="caution_alert">Dikkat Uyarısı</string>
+    <string name="warning_alert">Uyarı Uyarısı</string>
+    <string name="important_alert">Önemli Uyarı</string>
+    <string name="tip_alert">Bahşiş Uyarısı</string>
+    <string name="note_alert">Not Uyarısı</string>
     <string name="math">Matematik</string>
     <string name="horizontal_rule">Yatay Çizgi</string>
     <string name="task_list">Görev Listesi</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -94,11 +94,11 @@
     <string name="code">代码</string>
     <string name="quote">引用</string>
     <string name="alert">警报</string>
-    <string name="caution_alert">警告警报</string>
-    <string name="warning_alert">警告警报</string>
-    <string name="important_alert">重要警报</string>
-    <string name="tip_alert">提示警报</string>
-    <string name="note_alert">注意警报</string>
+    <string name="caution_alert">谨慎提醒</string>
+    <string name="warning_alert">警告提醒</string>
+    <string name="important_alert">重要提醒</string>
+    <string name="tip_alert">提示信息</string>
+    <string name="note_alert">备注提醒</string>
     <string name="math">数学</string>
     <string name="horizontal_rule">分割线</string>
     <string name="task_list">任务列表</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -93,6 +93,12 @@
     <string name="preview">预览</string>
     <string name="code">代码</string>
     <string name="quote">引用</string>
+    <string name="alert">警报</string>
+    <string name="caution_alert">警告警报</string>
+    <string name="warning_alert">警告警报</string>
+    <string name="important_alert">重要警报</string>
+    <string name="tip_alert">提示警报</string>
+    <string name="note_alert">注意警报</string>
     <string name="math">数学</string>
     <string name="horizontal_rule">分割线</string>
     <string name="task_list">任务列表</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -95,6 +95,7 @@
     <string name="preview">Preview</string>
     <string name="code">Code</string>
     <string name="quote">Quote</string>
+    <string name="alert">Alert</string>
     <string name="math">Math</string>
     <string name="horizontal_rule">Horizontal Rule</string>
     <string name="task_list">Task List</string>
@@ -204,4 +205,9 @@
     <string name="display_style">Display Style</string>
     <string name="line_numbers">Line numbers</string>
     <string name="sample_note">Sample Note</string>
+    <string name="caution_alert">Caution Alert</string>
+    <string name="warning_alert">Warning Alert</string>
+    <string name="important_alert">Important Alert</string>
+    <string name="tip_alert">Tip Alert</string>
+    <string name="note_alert">Note Alert</string>
 </resources>


### PR DESCRIPTION
### Summary

This PR introduces GitHub’s alert markdown extension to the Open Note application, resolving issue #59. The alerts follow GitHub’s standard syntax as documented [here](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts).

### Changes Made

- Implemented GitHub-style alert rendering in `template.html` using custom CSS and JavaScript for parsing.
- Integrated alert type selection (e.g., NOTE, TIP, WARNING) into the `EditRow` component, enabling users to easily specify the alert type when editing markdown.

### Screenshots

Below is a screenshot demonstrating how alerts are rendered in the app:
![Rendered GitHub-style alerts in the markdown viewer](https://github.com/user-attachments/assets/82c20983-c190-417a-9341-07a427e55f4c)

### Linked Issue

Closes #59